### PR TITLE
[DO-NOT-MERGE] Disable the gem for easy removal

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,10 @@
-# encoding: utf-8
 # frozen_string_literal: true
+
 require 'bundler'
 Bundler.setup
 
 require 'rake'
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)

--- a/lib/open-uri-s3.rb
+++ b/lib/open-uri-s3.rb
@@ -1,41 +1,16 @@
 # frozen_string_literal: true
-require 'aws-sdk-v1'
+
 require 'open-uri'
 require 'uri'
 
 module URI
   class S3 < Generic
-    # @return [AWS::S3::S3Object] S3 object (quacks like IO)
     def open(*_args)
-      options = {}
-      options[:use_ssl] = false if ENV['AWS_USE_SSL'] == 'false'
-      if ENV['AWS_S3_ENDPOINT']
-        s3_endpoint_uri = URI(ENV['AWS_S3_ENDPOINT'])
-        AWS.config(s3_endpoint: s3_endpoint_uri.host, s3_port: s3_endpoint_uri.port)
-      end
-
-      s3 = ::AWS::S3.new(options)
-      bucket = s3.buckets[hostname]
-      if !ENV['AWS_S3_ENDPOINT'] && bucket.location_constraint
-        s3_endpoint = "s3-#{bucket.location_constraint}.amazonaws.com"
-        s3          = ::AWS::S3.new(options.update(s3_endpoint: s3_endpoint))
-        bucket      = s3.buckets[hostname]
-      end
-
-      path = self.path[1..-1]
-      object = bucket.objects[path]
-
-      if block_given?
-        yield object
-      else
-        object
-      end
+      warn "open-uri-s3#open is deprecated, please replace. called from #{caller_locations}"
     end
 
     def read
-      open(to_s).read
+      warn "open-uri-s3#read is deprecated, please replace. called from #{caller_locations}"
     end
   end
-
-  @@schemes['S3'] = S3
 end

--- a/lib/open-uri-s3/version.rb
+++ b/lib/open-uri-s3/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module OpenURIS3
-  VERSION='1.7.0'
+  VERSION='1.8.0-pre.1'
 end

--- a/lib/open-uri-s3/version.rb
+++ b/lib/open-uri-s3/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module OpenURIS3
-  VERSION='1.8.0-pre.1'
+  VERSION='1.8.0-rc.1'
 end

--- a/lib/open-uri-s3/version.rb
+++ b/lib/open-uri-s3/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module OpenURIS3
-  VERSION='1.8.0-rc.1'
+  VERSION='1.8.0-rc.2'
 end

--- a/open-uri-s3.gemspec
+++ b/open-uri-s3.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
   s.files        = Dir['{lib}/**/*.rb', 'bin/*', 'LICENSE.txt', '*.md']
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'aws-sdk-v1'
-
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'yard'

--- a/spec/lib/open-uri-s3_spec.rb
+++ b/spec/lib/open-uri-s3_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'open-uri-s3'
 
 describe URI::S3 do


### PR DESCRIPTION
This should indicate all places where the gem is called. As the calls are not that obvious `open`.

This is ment as a utility to make it easier to remove the occurrences of open in convert-workflow: https://trello.com/c/NJmmhNyL/677-13-upgrade-convert-workflow-to-the-latest-ruby